### PR TITLE
Online messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ ssl/*
 # Output dirs
 server/*
 client/*
+
+# Certificates
+python_server/server.cert
+python_server/server.key
+python_server/server.csr

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ client/*
 python_server/server.cert
 python_server/server.key
 python_server/server.csr
+python_server/*.olaf

--- a/python_server/debug_client.py
+++ b/python_server/debug_client.py
@@ -1,0 +1,76 @@
+import asyncio
+import websockets
+import json
+import ssl
+import sys
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import secrets
+import random
+
+random.seed(secrets.randbits(128))
+
+async def connect(message_type, uri):
+    # Generate RSA keys
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048
+    )
+    public_key = private_key.public_key()
+
+    # SSL context setup
+    ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ssl_context.load_verify_locations(cafile="server.cert")
+
+    # Message
+    message = None
+
+    hello_message = {
+        "type": "hello",
+        "data": {
+            "public_key": public_key.public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo).decode(),
+        },
+        "counter": 1,
+        "signature": "Temp"
+    }
+
+    public_chat_message = {
+        "type": "public_chat",
+        "data": {
+            "public_key": public_key.public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo).decode(),
+            "message": "Test message"
+        },
+        "counter": 1,
+        "signature": "Temp"
+    }
+        
+    while True:
+        try:
+            async with websockets.connect(uri, ssl=ssl_context) as websocket:
+                # Send the message
+                await websocket.send(json.dumps(hello_message))
+                await websocket.send(json.dumps(public_chat_message))
+
+                # Keep the connection alive and listen for incoming messages
+                async for message in websocket:
+                    print(f"Received message: {message}")
+
+        except (websockets.ConnectionClosedError, websockets.InvalidMessage) as e:
+            print(f"Connection error: {e}")
+            # Handle reconnection or other recovery logic here
+            await asyncio.sleep(1)  # Wait before trying to reconnect
+            
+if __name__ == "__main__":
+    
+    # Read message type from the command lien
+    message_type = sys.argv[1]
+    
+    # Read port from the command line
+    port = 2763
+    if (len(sys.argv) > 2):
+        port = sys.argv[2]
+        
+    uri = "wss://localhost:" + str(port)
+    
+    asyncio.run(connect(message_type, uri))

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -14,8 +14,9 @@ class MessageType(Enum):
     
     # Server-made messages
     SERVER_CONNECT = 100
-    CLIENT_UPDATE_REQUEST = 101
-    CLIENT_LIST = 102
+    CLIENT_LIST = 101
+    CLIENT_UPDATE_REQUEST = 102
+    CLIENT_UPDATE = 103
 
 def hash_string_sha256(input_string):
     """ Hashing helper. """

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -2,19 +2,32 @@ import asyncio
 import websockets
 import json
 import ssl
-import sys 
-
+import sys
 from enum import Enum
+import hashlib
 
-class MessageType(Enum):
+class MessageType(Enum):    
     HELLO = 0
     PUBLIC_CHAT = 1
-    
+    SERVER_CONNECT = 100
+
+def hash_string_sha256(input_string):
+    """ Hashing helper. """
+    sha256 = hashlib.sha256()
+    sha256.update(input_string.encode('utf-8'))
+    return sha256.hexdigest()
+
 class Server:
-    def __init__(self):
-        # Public key -> Client socket
-        self.clients = {}
+    def __init__(self, host, port):
+        # Server details
+        self.host = host
+        self.port = port
+        self.hostname = f"{host}:{port}"
         
+        self.clients = {} # Socket -> Client Public Key
+        self.servers = {} # Socket -> Server Hostname
+        self.past_messages = []
+
         # Setup SSL context
         self.ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         self.ssl_context.options |= ssl.OP_NO_SSLv2
@@ -25,57 +38,154 @@ class Server:
 
         # Load certificate chain
         self.ssl_context.load_cert_chain(certfile="python_server/server.cert", keyfile="python_server/server.key")
+
+    async def start_server(self):
+        """ Begin the server and its core functions. """
         
-    def start_server(self, port):
-        server_loop = websockets.serve(self.handle_client, "localhost", port, ssl=self.ssl_context)
+        server_loop = websockets.serve(self.handle_client, self.host, self.port, ssl=self.ssl_context)
         
-        asyncio.get_event_loop().run_until_complete(server_loop)
-        asyncio.get_event_loop().run_forever()
+        # Create listeners
+        async with server_loop:
+            # Start the server loop
+            print(f"Server started on {self.hostname}")
+            server_task = asyncio.create_task(self.wait_for_shutdown())
+            
+            # Establish neighborhood connections
+            await self.connect_to_neighbourhood()
+
+            # Wait until server is manually stopped
+            await server_task
     
-    async def handle_client(self, websocket, path):
+    async def wait_for_shutdown(self):
+        """ Shutdown waiter to keep the server alive. """
+        
+        try:
+            await asyncio.Future()  # Run the server until manually stopped
+            
+        except asyncio.CancelledError:
+            print("Server is shutting down.")
+
+    async def connect_to_neighbourhood(self):
+        """ Connect to all servers in the neighbourhood. """
+        
+        # The message to connect to a server
+        connect_message = { 
+            "message_type": MessageType.SERVER_CONNECT.value, 
+            "data": {
+                "hostname": self.hostname
+            }
+        }
+           
+        # The auth context of the server you are connecting to (TODO: Get the cert of the server you want to connect to)
+        auth_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        auth_context.load_verify_locations(cafile="python_server/server.cert")
+    
+        # Iterate through servers in the list
+        with open('python_server/neighbourhood.olaf', 'r') as file:
+            for connecting_hostname in file:
+                connecting_hostname = connecting_hostname.strip()  # Ensure no leading/trailing whitespace
+                
+                # Don't connect to yourself, silly!
+                if (connecting_hostname == self.hostname):
+                    continue
+                
+                try:
+                    connecting_websocket = await websockets.connect(f"wss://{connecting_hostname}", ssl=auth_context)
+                    await connecting_websocket.send(json.dumps(connect_message))
+                    self.servers[connecting_hostname] = connecting_websocket
+                    
+                except:
+                    print(f"Could not reach server: {connecting_hostname}")
+
+    async def handle_client(self, websocket, path):   
+        """ Handle all messages. """
+             
         try:
             async for message in websocket:
                 message_json = json.loads(message)
                 message_type = MessageType(message_json.get('message_type'))
                 message_data = message_json.get('data')
                 
-                if MessageType(message_type) == MessageType.HELLO:
-                    await self.handle_hello(websocket, message_data)
+                if (message_json not in self.past_messages):
+                    self.past_messages.append(message_json)
                     
-                elif MessageType(message_type) == MessageType.PUBLIC_CHAT:
-                    await self.handle_public_chat(websocket, message_data)
-                    
-                else:
-                    print("Message type not recognised")
+                    # Handle message
+                    if message_type == MessageType.SERVER_CONNECT:
+                        await self.handle_server_connect(message_data)
+                        
+                    elif message_type == MessageType.HELLO:
+                        await self.handle_hello(websocket, message_data)
+
+                    elif message_type == MessageType.PUBLIC_CHAT:
+                        await self.handle_public_chat(message_data)
+                        
+                    else:
+                        print("Message type not recognized")
+                        
+                    # Forward message if appropriate
+                    if message_type == MessageType.PUBLIC_CHAT:
+                        await self.propagate_message(message)
                 
         finally:
-            # Always clean up and notify others of the disconnection
-            if websocket in self.clients:
-                disconnected_pub_key = self.clients.pop(websocket)
-                # TODO: Notify clients and servers
+            # TODO: Handle client disconnects
+            pass
 
-    async def handle_hello(self, websocket, message_data):   
+    async def handle_server_connect(self, message_data):
+        """ Handle SERVER_CONNECT messages. """
+        
+        # Don't connect to yourself, silly!
+        connecting_hostname = message_data.get('hostname')
+        if (connecting_hostname == self.hostname):
+            return
+        
+        try:
+            auth_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+            auth_context.load_verify_locations(cafile="python_server/server.cert")
+        
+            connecting_socket = await websockets.connect(f"wss://{connecting_hostname}", ssl=auth_context)
+            self.servers[connecting_hostname] = connecting_socket
+
+            print(f"Server connected with hostname: {connecting_hostname}")
+        
+        except:
+            print(f"Failed to send message to neighbor: {connecting_hostname}")
+        
+    async def handle_hello(self, websocket, message_data):
+        """ Handle HELLO messages. """
+         
         # Register client              
         pub_key = message_data.get('public_key')
-        self.clients[websocket] = pub_key
+        self.clients[pub_key] = websocket
         
         # Log join event
         print(f"Client connected with public key: {pub_key}")
+
+    async def handle_public_chat(self, message_data):
+        """ Handle PUBLIC_CHAT messages. """
         
-    async def handle_public_chat(self, websocket, message_data):
         # Extract public key and message
         pub_key = message_data.get('public_key')
         message = message_data.get('message')
         
-        for client in self.clients:
-            await client.send(f"From {pub_key}: {message}")
+        # Send public chat message to all clients
+        for _, client_socket in self.clients.items():
+            await client_socket.send(f"From {pub_key}: {message}")
+
+    async def propagate_message(self, message):
+        """ Propogate a message to all connected clients of the server. """
+        
+        for hostname, server_socket in self.servers.items():
+            try:
+                await server_socket.send(message)
+            except:
+                print(f"Failed to send message to neighbor: {hostname}")
 
 if __name__ == "__main__":
     # Read port from the command line
     port = 1443
-    if (len(sys.argv) > 1):
-        port = sys.argv[1]
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])  # Ensure port is an integer
         
     # Begin and run server
-    server = Server()
-    server.start_server(port)
+    server = Server("localhost", port)
+    asyncio.run(server.start_server())

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -253,6 +253,7 @@ class Server:
         for _, client_socket in self.clients.items():
             await client_socket.send(json.dumps(message))
        
+       
     async def handle_client_list_request(self, websocket):
         """ Handle CLIENT_LIST_REQUEST messages (respond with CLIENT_LIST). """
         

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -309,11 +309,20 @@ class Server:
     async def propagate_message(self, message):
         """ Propogate a message to all connected clients of the server. """
         
+        server_misses = []
+        
         for hostname, server_socket in self.servers.items():
             try:
                 await server_socket.send(message)
-            except Exception as e:
-                print(f"Failed to send message to neighbor: {hostname} {e}")
+            except:
+                print(f"Failed to send message to neighbor: {hostname}")
+                server_misses.append(hostname)
+                
+                
+        for hostname in server_misses:
+            del self.servers[hostname]
+            del self.all_clients[hostname]
+            print(f"Server disconnected with hostname: {hostname}")
 
 
 if __name__ == "__main__":

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -240,7 +240,7 @@ class Server:
         
         # Send public chat message to all clients
         for _, client_socket in self.clients.items():
-            await client_socket.send(message)
+            await client_socket.send(json.dumps(message))
             
     async def handle_client_list_request(self, websocket):
         """ Handle CLIENT_LIST_REQUEST messages (respond with CLIENT_LIST). """

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -6,6 +6,7 @@ import sys
 from enum import Enum
 import hashlib
 
+
 class MessageType(Enum):    
     # Client-made messages
     HELLO = 0
@@ -18,11 +19,13 @@ class MessageType(Enum):
     CLIENT_UPDATE_REQUEST = 102
     CLIENT_UPDATE = 103
 
+
 def hash_string_sha256(input_string):
     """ Hashing helper. """
     sha256 = hashlib.sha256()
     sha256.update(input_string.encode('utf-8'))
     return sha256.hexdigest()
+
 
 class Server:
     def __init__(self, host, port):
@@ -51,6 +54,7 @@ class Server:
 
         # Load certificate chain
         self.ssl_context.load_cert_chain(certfile="python_server/server.cert", keyfile="python_server/server.key")
+
 
     def create_message(self, message_type):
         self.counter = self.counter + 1
@@ -95,6 +99,7 @@ class Server:
                 "counter": self.counter
             }
             return message
+  
         
     async def start_server(self):
         """ Begin the server and its core functions. """
@@ -113,6 +118,7 @@ class Server:
             # Wait until server is manually stopped
             await server_task
     
+   
     async def wait_for_shutdown(self):
         """ Shutdown waiter to keep the server alive. """
         
@@ -121,6 +127,7 @@ class Server:
             
         except asyncio.CancelledError:
             print("Server is shutting down.")
+
 
     async def connect_to_neighbourhood(self):
         """ Connect to all servers in the neighbourhood. """
@@ -155,6 +162,7 @@ class Server:
                     
                 except:
                     print(f"Could not reach server: {connecting_hostname}")
+
 
     async def handle_client(self, websocket, path):   
         """ Handle all messages. """
@@ -199,6 +207,7 @@ class Server:
             # TODO: Handle client disconnects
             pass
 
+
     async def handle_server_connect(self, message_data):
         """ Handle SERVER_CONNECT messages. """
         
@@ -220,6 +229,7 @@ class Server:
         except:
             print(f"Failed to send message to neighbor: {connecting_hostname}")
         
+
     async def handle_hello(self, websocket, message_data):
         """ Handle HELLO messages. """
          
@@ -235,18 +245,20 @@ class Server:
         # Log join event
         print(f"Client connected with public key: {pub_key}")
 
+
     async def handle_public_chat(self, message):
         """ Handle PUBLIC_CHAT messages. """
         
         # Send public chat message to all clients
         for _, client_socket in self.clients.items():
             await client_socket.send(json.dumps(message))
-            
+       
     async def handle_client_list_request(self, websocket):
         """ Handle CLIENT_LIST_REQUEST messages (respond with CLIENT_LIST). """
         
         client_list_message = self.create_message(MessageType.CLIENT_LIST)
         await websocket.send(json.dumps(client_list_message))       
+  
   
     async def handle_client_update_request(self, message_data):
         """ Handle CLIENT_UPDATE_REQUEST messages (respond with CLIENT_UPDATE). """
@@ -255,6 +267,7 @@ class Server:
         client_update_message = self.create_message(MessageType.CLIENT_UPDATE)
         
         await self.servers[connecting_hostname].send(json.dumps(client_update_message))
+  
   
     async def handle_client_update(self, message_data):
         """ Handle CLIENT_UPDATE message. """
@@ -265,6 +278,7 @@ class Server:
         self.all_clients[hostname] = client_list
         print(f"Updated client list to: {self.all_clients}")  
   
+  
     async def propagate_message(self, message):
         """ Propogate a message to all connected clients of the server. """
         
@@ -273,6 +287,7 @@ class Server:
                 await server_socket.send(message)
             except Exception as e:
                 print(f"Failed to send message to neighbor: {hostname} {e}")
+
 
 if __name__ == "__main__":
     # Read port from the command line

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -7,12 +7,12 @@ from enum import Enum
 import hashlib
 
 
-class MessageType(Enum):    
+class MessageType(Enum):
     # Client-made messages
     HELLO = 0
     PUBLIC_CHAT = 1
     CLIENT_LIST_REQUEST = 2
-    
+
     # Server-made messages
     SERVER_CONNECT = 100
     CLIENT_LIST = 101
@@ -33,15 +33,15 @@ class Server:
         self.host = host
         self.port = port
         self.hostname = f"{host}:{port}"
-        
-        self.clients = {} # Socket -> Client Public Key
-        self.servers = {} # Socket -> Server Hostname
-        
-        self.all_clients = {} # Server hostname -> User List
+
+        self.clients = {}  # Socket -> Client Public Key
+        self.servers = {}  # Socket -> Server Hostname
+
+        self.all_clients = {}  # Server hostname -> User List
         self.all_clients[self.hostname] = []
-        
+
         self.counter = 0
-        
+
         self.last_message = None
 
         # Setup SSL context
@@ -53,272 +53,264 @@ class Server:
         self.ssl_context.options |= ssl.OP_SINGLE_DH_USE
 
         # Load certificate chain
-        self.ssl_context.load_cert_chain(certfile="python_server/server.cert", keyfile="python_server/server.key")
-
+        self.ssl_context.load_cert_chain(
+            certfile="python_server/server.cert", keyfile="python_server/server.key")
 
     def create_message(self, message_type):
         self.counter = self.counter + 1
-        
+
         if (message_type == MessageType.SERVER_CONNECT):
-            message = { 
-                "message_type": MessageType.SERVER_CONNECT.value, 
-                "data": { 
-                    "hostname": self.hostname 
+            message = {
+                "message_type": MessageType.SERVER_CONNECT.value,
+                "data": {
+                    "hostname": self.hostname
                 },
                 "counter": self.counter
             }
             return message
-         
+
         elif (message_type == MessageType.CLIENT_LIST):
-            message = { 
-                "message_type": MessageType.CLIENT_LIST.value, 
+            message = {
+                "message_type": MessageType.CLIENT_LIST.value,
                 "data": {
                     "servers": self.all_clients
                 },
                 "counter": self.counter
             }
-            return message    
-            
+            return message
+
         elif (message_type == MessageType.CLIENT_UPDATE_REQUEST):
-            message = { 
-                "message_type": MessageType.CLIENT_UPDATE_REQUEST.value, 
-                "data": { 
+            message = {
+                "message_type": MessageType.CLIENT_UPDATE_REQUEST.value,
+                "data": {
                     "hostname": self.hostname
                 },
                 "counter": self.counter
             }
-            return message    
-            
+            return message
+
         elif (message_type == MessageType.CLIENT_UPDATE):
-            message = { 
-                "message_type": MessageType.CLIENT_UPDATE.value, 
-                "data": { 
+            message = {
+                "message_type": MessageType.CLIENT_UPDATE.value,
+                "data": {
                     "hostname": self.hostname,
-                    "clients": list(self.clients.keys()) 
+                    "clients": list(self.clients.keys())
                 },
                 "counter": self.counter
             }
             return message
-  
-        
+
     async def start_server(self):
         """ Begin the server and its core functions. """
-        
-        server_loop = websockets.serve(self.handle_client, self.host, self.port, ssl=self.ssl_context)
-        
+
+        server_loop = websockets.serve(
+            self.handle_client, self.host, self.port, ssl=self.ssl_context)
+
         # Create listeners
         async with server_loop:
             # Start the server loop
             print(f"Server started on {self.hostname}")
             server_task = asyncio.create_task(self.wait_for_shutdown())
-            
+
             # Establish neighborhood connections
             await self.connect_to_neighbourhood()
 
             # Wait until server is manually stopped
             await server_task
-    
-   
+
     async def wait_for_shutdown(self):
         """ Shutdown waiter to keep the server alive. """
-        
+
         try:
             await asyncio.Future()  # Run the server until manually stopped
-            
+
         except asyncio.CancelledError:
             print("Server is shutting down.")
 
-
     async def connect_to_neighbourhood(self):
         """ Connect to all servers in the neighbourhood. """
-        
+
         # Consturct messages
         connect_message = self.create_message(MessageType.SERVER_CONNECT)
-        client_update_request_message = self.create_message(MessageType.CLIENT_UPDATE_REQUEST)
-             
+        client_update_request_message = self.create_message(
+            MessageType.CLIENT_UPDATE_REQUEST)
+
         # The auth context of the server you are connecting to (TODO: Get the cert of the server you want to connect to)
         auth_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         auth_context.load_verify_locations(cafile="python_server/server.cert")
-    
+
         # Iterate through servers in the list
         with open('python_server/neighbourhood.olaf', 'r') as file:
             for connecting_hostname in file:
-                connecting_hostname = connecting_hostname.strip()  # Ensure no leading/trailing whitespace
-                
+                # Ensure no leading/trailing whitespace
+                connecting_hostname = connecting_hostname.strip()
+
                 # Don't connect to yourself, silly!
                 if (connecting_hostname == self.hostname):
                     continue
-                
+
                 try:
                     connecting_websocket = await websockets.connect(f"wss://{connecting_hostname}", ssl=auth_context)
-                    
+
                     # Connect to the server with a two-way channel
                     await connecting_websocket.send(json.dumps(connect_message))
                     self.servers[connecting_hostname] = connecting_websocket
                     self.all_clients[connecting_hostname] = []
-                    
+
                     # Get the online list of users
                     await connecting_websocket.send(json.dumps(client_update_request_message))
-                    
+
                 except:
                     print(f"Could not reach server: {connecting_hostname}")
 
-
-    async def handle_client(self, websocket, path):   
+    async def handle_client(self, websocket, path):
         """ Handle all messages. """
-             
+
         try:
             async for message in websocket:
                 message_json = json.loads(message)
                 message_type = MessageType(message_json.get('message_type'))
                 message_data = message_json.get('data')
-                
+
                 # Ignore if message was identical to the most recent one (DOS and loop protection)
                 if (hash_string_sha256(message) != self.last_message):
                     self.last_message = hash_string_sha256(message)
- 
+
                     # Handle message
                     if message_type == MessageType.SERVER_CONNECT:
                         await self.handle_server_connect(message_data)
-                        
+
                     elif message_type == MessageType.HELLO:
                         await self.handle_hello(websocket, message_data)
 
                     elif message_type == MessageType.PUBLIC_CHAT:
                         await self.handle_public_chat(message)
-                        
+
                     elif message_type == MessageType.CLIENT_LIST_REQUEST:
                         await self.handle_client_list_request(websocket)
-                        
+
                     elif message_type == MessageType.CLIENT_UPDATE_REQUEST:
                         await self.handle_client_update_request(message_data)
-                        
+
                     elif message_type == MessageType.CLIENT_UPDATE:
                         await self.handle_client_update(message_data)
-                        
+
                     else:
                         print("Message type not recognized")
-                        
+
                     # Forward message if appropriate
                     if message_type == MessageType.PUBLIC_CHAT:
                         await self.propagate_message(message)
-                
+
         except Exception as e:
             await self.handle_client_disconnect(websocket)
-            
+
         finally:
             # Ensure client cleanup on disconnect
             await self.handle_client_disconnect(websocket)
 
-
     async def handle_client_disconnect(self, websocket):
         """ Handle client disconnection. """
-        
+
         # Find the client by websocket
         pub_key_to_remove = None
         for pub_key, client_socket in self.clients.items():
             if client_socket == websocket:
                 pub_key_to_remove = pub_key
                 break
-        
+
         if pub_key_to_remove:
             # Remove the client
             del self.clients[pub_key_to_remove]
             self.all_clients[self.hostname].remove(pub_key_to_remove)
-            
+
             # Log disconnect event
             print(f"Client disconnected with public key: {pub_key_to_remove}")
-            
-            # Notify other servers about the update
-            client_update_message = self.create_message(MessageType.CLIENT_UPDATE)
-            await self.propagate_message(json.dumps(client_update_message))
 
+            # Notify other servers about the update
+            client_update_message = self.create_message(
+                MessageType.CLIENT_UPDATE)
+            await self.propagate_message(json.dumps(client_update_message))
 
     async def handle_server_connect(self, message_data):
         """ Handle SERVER_CONNECT messages. """
-        
+
         # Don't connect to yourself, silly!
         connecting_hostname = message_data.get('hostname')
         if (connecting_hostname == self.hostname):
             return
-        
+
         try:
             auth_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-            auth_context.load_verify_locations(cafile="python_server/server.cert")
-        
+            auth_context.load_verify_locations(
+                cafile="python_server/server.cert")
+
             connecting_socket = await websockets.connect(f"wss://{connecting_hostname}", ssl=auth_context)
             self.servers[connecting_hostname] = connecting_socket
             self.all_clients[connecting_hostname] = []
 
             print(f"Server connected with hostname: {connecting_hostname}")
-        
+
         except:
             print(f"Failed to send message to neighbor: {connecting_hostname}")
-        
 
     async def handle_hello(self, websocket, message_data):
         """ Handle HELLO messages. """
-         
-        # Register client              
+
+        # Register client
         pub_key = message_data.get('public_key')
         self.clients[pub_key] = websocket
 
         self.all_clients[self.hostname].append(pub_key)
-        
+
         client_update_message = self.create_message(MessageType.CLIENT_UPDATE)
         await self.propagate_message(json.dumps(client_update_message))
-        
+
         # Log join event
         print(f"Client connected with public key: {pub_key}")
 
-
     async def handle_public_chat(self, message):
         """ Handle PUBLIC_CHAT messages. """
-        
+
         # Send public chat message to all clients
         for _, client_socket in self.clients.items():
             await client_socket.send(json.dumps(message))
-       
-       
+
     async def handle_client_list_request(self, websocket):
         """ Handle CLIENT_LIST_REQUEST messages (respond with CLIENT_LIST). """
-        
+
         client_list_message = self.create_message(MessageType.CLIENT_LIST)
-        await websocket.send(json.dumps(client_list_message))       
-  
-  
+        await websocket.send(json.dumps(client_list_message))
+
     async def handle_client_update_request(self, message_data):
         """ Handle CLIENT_UPDATE_REQUEST messages (respond with CLIENT_UPDATE). """
-        
+
         connecting_hostname = message_data.get('hostname')
         client_update_message = self.create_message(MessageType.CLIENT_UPDATE)
-        
+
         await self.servers[connecting_hostname].send(json.dumps(client_update_message))
-  
-  
+
     async def handle_client_update(self, message_data):
         """ Handle CLIENT_UPDATE message. """
-        
+
         hostname = message_data.get('hostname')
         client_list = message_data.get('clients')
-        
+
         self.all_clients[hostname] = client_list
-        print(f"Updated client list to: {self.all_clients}")  
-  
-  
+        print(f"Updated client list to: {self.all_clients}")
+
     async def propagate_message(self, message):
         """ Propogate a message to all connected clients of the server. """
-        
+
         server_misses = []
-        
+
         for hostname, server_socket in self.servers.items():
             try:
                 await server_socket.send(message)
             except:
                 print(f"Failed to send message to neighbor: {hostname}")
                 server_misses.append(hostname)
-                
-                
+
         for hostname in server_misses:
             del self.servers[hostname]
             del self.all_clients[hostname]
@@ -330,7 +322,7 @@ if __name__ == "__main__":
     port = 1443
     if len(sys.argv) > 1:
         port = int(sys.argv[1])  # Ensure port is an integer
-        
+
     # Begin and run server
     server = Server("localhost", port)
     asyncio.run(server.start_server())

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -189,7 +189,7 @@ class Server:
         
         self.online_list.append(pub_key)
         
-        # Propogate client update
+        # The message to update servers about the online list
         client_update_message = { 
             "message_type": MessageType.CLIENT_UPDATE.value, 
             "data": {
@@ -215,14 +215,22 @@ class Server:
     async def handle_client_list_request(self, websocket):
         """ Handle CLIENT_LIST_REQUEST messages (respond with CLIENT_LIST). """
         
-        await websocket.send(f"REPLY")       
+        # The message to clients servers about the online list
+        client_list_message = { 
+            "message_type": MessageType.CLIENT_LIST.value, 
+            "data": {
+                "clients": self.online_list,
+            }
+        }
+        
+        await websocket.send(f"[INSERT CLIENT_LIST HERE]")       
   
     async def handle_client_update_request(self, message_data):
         """ Handle CLIENT_UPDATE_REQUEST messages (respond with CLIENT_UPDATE). """
         
         connecting_hostname = message_data.get('hostname')
         
-        # The message to connect to a server
+        # The message to update servers about the online list
         client_update_message = { 
             "message_type": MessageType.CLIENT_UPDATE.value, 
             "data": {

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -1,0 +1,81 @@
+import asyncio
+import websockets
+import json
+import ssl
+import sys 
+
+from enum import Enum
+
+class MessageType(Enum):
+    HELLO = 0
+    PUBLIC_CHAT = 1
+    
+class Server:
+    def __init__(self):
+        # Public key -> Client socket
+        self.clients = {}
+        
+        # Setup SSL context
+        self.ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        self.ssl_context.options |= ssl.OP_NO_SSLv2
+        self.ssl_context.options |= ssl.OP_NO_SSLv3
+        self.ssl_context.options |= ssl.OP_NO_TLSv1
+        self.ssl_context.options |= ssl.OP_NO_TLSv1_1
+        self.ssl_context.options |= ssl.OP_SINGLE_DH_USE
+
+        # Load certificate chain
+        self.ssl_context.load_cert_chain(certfile="python_server/server.cert", keyfile="python_server/server.key")
+        
+    def start_server(self, port):
+        server_loop = websockets.serve(self.handle_client, "localhost", port, ssl=self.ssl_context)
+        
+        asyncio.get_event_loop().run_until_complete(server_loop)
+        asyncio.get_event_loop().run_forever()
+    
+    async def handle_client(self, websocket, path):
+        try:
+            async for message in websocket:
+                message_json = json.loads(message)
+                message_type = int(message_json.get('message_type'))
+                message_data = message_json.get('data')
+                
+                if message_type == MessageType.HELLO:
+                    await self.handle_hello(websocket, message_data)
+                    
+                if message_type == MessageType.PUBLIC_CHAT:
+                    await self.handle_public_chat(websocket, message_data)
+                    
+                else:
+                    print("Message type not recognised")
+                
+        finally:
+            # Always clean up and notify others of the disconnection
+            if websocket in self.clients:
+                disconnected_pub_key = self.clients.pop(websocket)
+                # TODO: Notify clients and servers
+
+    async def handle_hello(self, websocket, message_data):   
+        # Register client              
+        pub_key = message_data.get('public_key')
+        self.clients[websocket] = pub_key
+        
+        # Log join event
+        print(f"Client connected with public key: {pub_key}")
+        
+    async def handle_public_chat(self, websocket, message_data):
+        # Extract public key and message
+        pub_key = message_data.get('public_key')
+        message = message_data.get('message')
+        
+        for client in self.clients:
+            await client.send(f"From {pub_key}: {message}")
+
+if __name__ == "__main__":
+    # Read port from the command line
+    port = 1443
+    if (len(sys.argv) > 1):
+        port = sys.argv[1]
+        
+    # Begin and run server
+    server = Server()
+    server.start_server(port)

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -36,13 +36,13 @@ class Server:
         try:
             async for message in websocket:
                 message_json = json.loads(message)
-                message_type = int(message_json.get('message_type'))
+                message_type = MessageType(message_json.get('message_type'))
                 message_data = message_json.get('data')
                 
-                if message_type == MessageType.HELLO:
+                if MessageType(message_type) == MessageType.HELLO:
                     await self.handle_hello(websocket, message_data)
                     
-                if message_type == MessageType.PUBLIC_CHAT:
+                elif MessageType(message_type) == MessageType.PUBLIC_CHAT:
                     await self.handle_public_chat(websocket, message_data)
                     
                 else:

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -3,7 +3,7 @@
 
 class Client {
 public:
-    Client(std::string public_key): m_public_key(public_key) {}
+    Client(std::string public_key): m_public_key(public_key), m_counter(0) {}
 
     std::string getPublicKey();
     uint32_t getCounter();

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -54,6 +54,17 @@ void cli(Connection &&connection, Client &&client) {
             nlohmann::json message_json = message.to_json();
             connection.write(message_json.dump(4));
 
+        } else if (command == "online_list") {
+
+            auto message_data = std::make_unique<ClientListRequest>();
+
+            Message message{MessageType::CLIENT_LIST_REQUEST,
+                            std::move(message_data), client.getCounter(),
+                            "temp_signature"};
+
+            nlohmann::json message_json = message.to_json();
+            connection.write(message_json.dump(4));
+
         } else if (command == "quit") {
             return;
         }

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -6,13 +6,23 @@
 #include <thread>
 
 void cli(Connection &&connection, Client &&client) {
-
     {
         auto message_data = std::make_unique<HelloData>();
         message_data->m_public_key = client.getPublicKey();
 
         Message message{MessageType::HELLO, std::move(message_data),
                         client.getCounter(), "temp_signature"};
+
+        nlohmann::json message_json = message.to_json();
+        connection.write(message_json.dump(4));
+    }
+
+    {
+        auto message_data = std::make_unique<ClientListRequest>();
+
+        Message message{MessageType::CLIENT_LIST_REQUEST,
+                        std::move(message_data), client.getCounter(),
+                        "temp_signature"};
 
         nlohmann::json message_json = message.to_json();
         connection.write(message_json.dump(4));

--- a/src/messages/messages.cpp
+++ b/src/messages/messages.cpp
@@ -2,7 +2,7 @@
 
 MessageType HelloData::type() { return MessageType::HELLO; }
 MessageType PublicChatData::type() { return MessageType::PUBLIC_CHAT; }
-
+MessageType ClientListRequest::type() { return MessageType::CLIENT_LIST_REQUEST; }
 
 nlohmann::json HelloData::to_json() {
     nlohmann::json j;
@@ -19,6 +19,12 @@ nlohmann::json PublicChatData::to_json() {
     return j;
 }
 
+nlohmann::json ClientListRequest::to_json() {
+    nlohmann::json j;
+    j["type"] = static_cast<uint8_t>(type());
+    return j;
+}
+
 nlohmann::json Message::to_json() {
     nlohmann::json j;
     j["message_type"] = static_cast<uint8_t>(m_message_type);
@@ -27,36 +33,3 @@ nlohmann::json Message::to_json() {
     j["signature"] = m_signature;
     return j;
 }
-
-/*
-int main() {
-    auto hello_data = std::make_unique<HelloData>();
-    hello_data->m_public_key = "my_public_key";
-
-    Message message{MessageType::HELLO, std::move(hello_data), 123,
-                    "signature"};
-
-    nlohmann::json j = message.to_json();
-    std::cout << "Packed JSON: " << j.dump(4) << std::endl;
-
-    Message deserialized_message = Message::from_json(j);
-
-    std::cout << "Unpacked Message Type: "
-              << static_cast<uint8_t>(deserialized_message.m_message_type)
-              << std::endl;
-    std::cout << "Unpacked Public Key: "
-              << static_cast<HelloData *>(deserialized_message.m_data.get())
-                     ->m_public_key
-              << std::endl;
-
-    std::cout << "Unpacked Counter: "
-              << static_cast<uint32_t>(deserialized_message.m_counter)
-              << std::endl;
-
-    std::cout << "Unpacked Signature: "
-              << static_cast<std::string>(deserialized_message.m_signature)
-              << std::endl;
-
-    return 0;
-}
-*/

--- a/src/messages/messages.hpp
+++ b/src/messages/messages.hpp
@@ -7,6 +7,7 @@
 enum class MessageType : uint8_t { 
     HELLO,
     PUBLIC_CHAT,
+    CLIENT_LIST_REQUEST,
 };
 
 class MessageData {
@@ -47,6 +48,17 @@ public:
     }
 };
 
+class ClientListRequest : public MessageData {
+public:
+    MessageType type();
+    nlohmann::json to_json();
+
+    static std::unique_ptr<ClientListRequest> from_json(const nlohmann::json& j) {
+        auto data = std::make_unique<ClientListRequest>();
+        return data;
+    }
+};
+
 
 class Message {
 public:
@@ -69,6 +81,9 @@ public:
             case MessageType::PUBLIC_CHAT:
                 message.m_data = PublicChatData::from_json(j["data"]);
                 break;
+            case MessageType::CLIENT_LIST_REQUEST:
+                message.m_data = ClientListRequest::from_json(j["data"]);
+
             default:
                 throw std::runtime_error("Unknown MessageType");
         }


### PR DESCRIPTION
Servers form two-way connections and can propagate messages between each other, either in a directed or a flooding way. Online lists are maintained upon update and given to servers/clients when they connect.

Currently supported messages:
- `HELLO`
- `PUBLIC_CHAT` (`public_chat` "message" in the CLI)
- `CLIENT_LIST`
- `CLIENT_LIST_REQUEST` (`online_list` in the CLI)
- `CLIENT_UPDATE`
- `CLIENT_UPDATE_REQUEST`

Server initialisation behaviour:
1. Come online
2. Try to connect to all servers
3. Request a client update from each connected server

Client initialisation behaviour:
1. Come online
2. Try to connect to your server
3. Request a client list from your server

Current (flawed) assumptions:
- All servers use the same certificate. (`neighbourhood.olaf` needs an upgrade).
- All messages are valid (signatures are not validated).

Issues fixed with this branch:
- Clients and servers can now disconnect in any way, for any reason, and the servers will not crash like they used to.
- See #15 and #16 
