### PR TITLE
Direct Messages (Private Chat)

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -12,6 +12,7 @@ class MessageType(Enum):
     # Client-made messages
     HELLO = "hello"
     PUBLIC_CHAT = "public_chat"
+    PRIVATE_CHAT = "private_chat"
     CLIENT_LIST_REQUEST = "client_list_request"
 
     # Server-made messages
@@ -209,6 +210,9 @@ class Server:
 
                     elif message_type == MessageType.PUBLIC_CHAT:
                         await self.handle_public_chat(message_json)
+                        
+                    elif message_type == MessageType.PRIVATE_CHAT:
+                        await self.handle_private_chat(message_json)
 
                     elif message_type == MessageType.CLIENT_LIST_REQUEST:
                         await self.handle_client_list_request(websocket)
@@ -327,7 +331,19 @@ class Server:
 
         self.all_clients[hostname] = client_list
         print(f"Updated client list to: {self.all_clients}")
-
+        
+    async def handle_private_chat(self, message):
+        """ Handle PRIVATE_CHAT message """
+        
+        message_data = message.get('data')
+        destination_servers = message_data.get('destination_servers')
+        unique_destinations = list(set(destination_servers))
+        
+        for destination in unique_destinations:
+            await self.servers[destination].send(
+                json.dumps(message)
+            )
+        
     async def propagate_message(self, message):
         """ Propogate a message to all connected clients of the server. """
 

--- a/server/server.py
+++ b/server/server.py
@@ -22,13 +22,6 @@ class MessageType(Enum):
     CLIENT_UPDATE = "client_update"
 
 
-def hash_string_sha256(input_string):
-    """ Hashing helper. """
-    sha256 = hashlib.sha256()
-    sha256.update(input_string.encode('utf-8'))
-    return sha256.hexdigest()
-
-
 class Server:
     def __init__(self, host, port):
         # Suppress specific deprecation warnings for SSL options
@@ -343,7 +336,8 @@ class Server:
         
         # The first participant (sender) always gets their message reflected back to them
         sender_pub_key = destination_clients[0]
-        await self.clients[sender_pub_key].send(json.dumps(message))
+        if self.clients.get(sender_pub_key) is not None:
+            await self.clients[sender_pub_key].send(json.dumps(message))
         
         # Propgate the message locally to all recieving users
         for i in range(len(destination_servers)):

--- a/server/server.py
+++ b/server/server.py
@@ -12,7 +12,7 @@ class MessageType(Enum):
     # Client-made messages
     HELLO = "hello"
     PUBLIC_CHAT = "public_chat"
-    PRIVATE_CHAT = "private_chat"
+    PRIVATE_CHAT = "chat"
     CLIENT_LIST_REQUEST = "client_list_request"
 
     # Server-made messages
@@ -336,13 +336,18 @@ class Server:
         """ Handle PRIVATE_CHAT message """
         
         message_data = message.get('data')
+        chat_data = message_data.get('chat')
+        destination_clients = chat_data.get('participants')
         destination_servers = message_data.get('destination_servers')
         unique_destinations = list(set(destination_servers))
         
-        for destination in unique_destinations:
-            await self.servers[destination].send(
-                json.dumps(message)
-            )
+        print(message_data)
+        print(destination_servers)
+                
+        for i in range(len(destination_servers)):
+            if (destination_servers[i] == self.hostname):
+                pub_key = destination_clients[i]
+                await self.clients[pub_key].send(json.dumps(message))
         
     async def propagate_message(self, message):
         """ Propogate a message to all connected clients of the server. """

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -92,9 +92,12 @@ inline void cli(Connection &&connection, Client &&client,
         } else {
             std::cerr << "Unknown command: " << command << "\n";
             std::cerr << "Known commands are:\n";
-            std::cerr << "\tpublic_chat [message]\tSend a message to everyone "
+            std::cerr << "\tpublic_chat [message]\tSend a message to everyone"
                          "in the neighbourhood\n";
             std::cerr << "\tonline_list\tList the currently online users"
+                      << std::endl;
+            std::cerr << "\tchat [N] [user1@hostname1] ... [userN@hostnameN] "
+                         "[message]\tSend a message to certain users"
                       << std::endl;
         }
     }

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -45,13 +45,34 @@ inline void cli(Connection &&connection, Client &&client,
 
         } else if (command == "chat") {
 
-            std::vector<std::string> servers = {"localhost:1443"};
-            std::vector<std::string> keys = {"Key1"};
-            std::vector<std::string> part = {"default"};
+            std::string canonical_user;
+            std::stringstream text_stream(text);
+
+            uint16_t num_users;
+            text_stream >> num_users;
+
+            std::vector<std::string> servers;
+            std::vector<std::string> symm_keys;
+            std::vector<std::string> participants = {client.getPublicKey()};
+
+            for (uint16_t i = 0; i < num_users; i++) {
+                text_stream >> canonical_user >> std::ws;
+
+                size_t pos = canonical_user.find("@");
+                std::string pub_key = canonical_user.substr(0, pos);
+                std::string server = canonical_user.substr(pos + 1);
+                std::string symm_key = "temp_key";
+
+                servers.push_back(server);
+                symm_keys.push_back(symm_key);
+                participants.push_back(pub_key);
+            }
+
+            std::getline(text_stream, text);
 
             auto message_data = std::make_unique<PrivateChatData>(
-                std::move(servers), "0", std::move(keys), std::move(part),
-                "Hello!");
+                std::move(servers), "0", std::move(symm_keys),
+                std::move(participants), text);
 
             Message message{MessageType::PRIVATE_CHAT, std::move(message_data)};
 

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -43,6 +43,21 @@ inline void cli(Connection &&connection, Client &&client,
             nlohmann::json message_json = message.to_json();
             connection.write(message_json.dump(4));
 
+        } else if (command == "chat") {
+
+            std::vector<std::string> servers = {"localhost:1443"};
+            std::vector<std::string> keys = {"Key1"};
+            std::vector<std::string> part = {"default"};
+
+            auto message_data = std::make_unique<PrivateChatData>(
+                std::move(servers), "0", std::move(keys), std::move(part),
+                "Hello!");
+
+            Message message{MessageType::PRIVATE_CHAT, std::move(message_data)};
+
+            nlohmann::json message_json = message.to_json();
+            connection.write(message_json.dump(4));
+
         } else if (command == "online_list") {
 
             auto message_data = std::make_unique<ClientListRequestData>();
@@ -52,6 +67,7 @@ inline void cli(Connection &&connection, Client &&client,
 
             nlohmann::json message_json = message.to_json();
             connection.write(message_json.dump(4));
+
         } else {
             std::cerr << "Unknown command: " << command << "\n";
             std::cerr << "Known commands are:\n";

--- a/src/messagehandler.cpp
+++ b/src/messagehandler.cpp
@@ -6,13 +6,16 @@
 
 auto MessageHandler::handle_message(std::string_view raw_message) const noexcept
     -> void {
-    // std::cerr << "[MESSAGE RECEIVED] " << raw_message << std::endl; // DEBUG
+    std::cerr << "[MESSAGE RECEIVED] " << raw_message << std::endl; // DEBUG
     try {
         auto message = Message::from_json(nlohmann::json::parse(raw_message));
 
         switch (message.type()) {
         case MessageType::PUBLIC_CHAT: {
             this->handle_public_chat(std::move(message));
+        }; break;
+        case MessageType::PRIVATE_CHAT: {
+            this->handle_private_chat(std::move(message));
         }; break;
         case MessageType::CLIENT_LIST: {
             this->handle_client_list(std::move(message));
@@ -39,6 +42,17 @@ auto MessageHandler::handle_public_chat(Message &&message) const -> void {
 
     std::cout << "[PUBLIC_CHAT] " << data.public_key() << ": " << data.message()
               << std::endl;
+}
+
+auto MessageHandler::handle_private_chat(Message &&message) const -> void {
+    if (!this->verify_message(message)) {
+        return;
+    }
+
+    const auto &data = static_cast<const PrivateChatData &>(message.data());
+
+    std::cout << "[PRIVATE_CHAT] " << data.participants().at(0) << ": "
+              << data.message() << std::endl;
 }
 
 auto MessageHandler::handle_client_list(Message &&message) const -> void {

--- a/src/messagehandler.cpp
+++ b/src/messagehandler.cpp
@@ -6,7 +6,7 @@
 
 auto MessageHandler::handle_message(std::string_view raw_message) const noexcept
     -> void {
-    std::cerr << "[MESSAGE RECEIVED] " << raw_message << std::endl; // DEBUG
+    // std::cerr << "[MESSAGE RECEIVED] " << raw_message << std::endl; // DEBUG
     try {
         auto message = Message::from_json(nlohmann::json::parse(raw_message));
 

--- a/src/messagehandler.hpp
+++ b/src/messagehandler.hpp
@@ -7,6 +7,7 @@ class MessageHandler {
   private:
     auto verify_message(const Message &message) const -> bool;
     auto handle_public_chat(Message &&message) const -> void;
+    auto handle_private_chat(Message &&message) const -> void;
     auto handle_client_list(Message &&message) const -> void;
 
   public:

--- a/src/messages.hpp
+++ b/src/messages.hpp
@@ -8,6 +8,7 @@
 enum class MessageType : uint8_t {
     HELLO,
     PUBLIC_CHAT,
+    PRIVATE_CHAT,
     CLIENT_LIST_REQUEST,
     CLIENT_LIST,
 };
@@ -16,6 +17,7 @@ namespace MessageTypeString {
 using namespace std::literals;
 static std::string_view hello = "hello"sv;
 static std::string_view public_chat = "public_chat"sv;
+static std::string_view private_chat = "chat"sv;
 static std::string_view client_list_request = "client_list_request"sv;
 static std::string_view client_list = "client_list"sv;
 }; // namespace MessageTypeString
@@ -99,6 +101,39 @@ class ClientListData : public MessageData {
 
   private:
     std::map<std::string_view, std::vector<std::string_view>> m_online_list;
+};
+
+class PrivateChatData : public MessageData {
+  public:
+    constexpr auto type() const -> MessageType;
+    auto to_json() const -> nlohmann::json;
+
+    explicit PrivateChatData(std::vector<std::string> &&destination_servers,
+                             std::string iv,
+                             std::vector<std::string> &&symm_keys,
+                             std::vector<std::string> &&participants,
+                             std::string message)
+        : m_destination_servers(std::move(destination_servers)), m_iv(iv),
+          m_symm_keys(std::move(symm_keys)),
+          m_participants(std::move(participants)), m_message(message) {}
+
+    static auto from_json(const nlohmann::json &j)
+        -> std::unique_ptr<PrivateChatData>;
+
+    inline auto message() const noexcept -> std::string_view {
+        return this->m_message;
+    };
+
+    inline auto participants() const noexcept -> std::vector<std::string> {
+        return this->m_participants;
+    };
+
+  private:
+    std::vector<std::string> m_destination_servers;
+    std::string m_iv;
+    std::vector<std::string> m_symm_keys;
+    std::vector<std::string> m_participants;
+    std::string m_message;
 };
 
 class Message {

--- a/src/messages.hpp
+++ b/src/messages.hpp
@@ -39,8 +39,8 @@ class HelloData : public MessageData {
     explicit HelloData(std::string_view public_key)
         : m_public_key(public_key) {}
 
-    static auto
-    from_json(const nlohmann::json &j) -> std::unique_ptr<HelloData>;
+    static auto from_json(const nlohmann::json &j)
+        -> std::unique_ptr<HelloData>;
 
   private:
     std::string m_public_key;
@@ -55,8 +55,8 @@ class PublicChatData : public MessageData {
                             std::string_view message)
         : m_public_key(public_key), m_message(message) {}
 
-    static auto
-    from_json(const nlohmann::json &j) -> std::unique_ptr<PublicChatData>;
+    static auto from_json(const nlohmann::json &j)
+        -> std::unique_ptr<PublicChatData>;
 
     inline auto message() const noexcept -> std::string_view {
         return this->m_message;
@@ -89,8 +89,8 @@ class ClientListData : public MessageData {
         std::map<std::string_view, std::vector<std::string_view>> &&online_list)
         : m_online_list(std::move(online_list)) {}
 
-    static auto
-    from_json(const nlohmann::json &j) -> std::unique_ptr<ClientListData>;
+    static auto from_json(const nlohmann::json &j)
+        -> std::unique_ptr<ClientListData>;
 
     auto users() const noexcept
         -> const std::map<std::string_view, std::vector<std::string_view>> & {


### PR DESCRIPTION
Servers and clients form two-way connections and can propagate messages between each other, either in a directed or a flooding way.
Currently supported messages:

- HELLO
- PUBLIC_CHAT (public_chat "message" in the CLI)
- CLIENT_LIST
- CLIENT_LIST_REQUEST (online_list in the CLI)
- CLIENT_UPDATE
- CLIENT_UPDATE_REQUEST
- PRIVATE_CHAT (chat in the CLI)

Current (flawed) assumptions:

- All servers use the same certificate. (neighbourhood.olaf needs an upgrade).
- All messages are valid (signatures are not validated).