### PR TITLE
add limit to max participants in group chat on client side

### DIFF
--- a/src/messagehandler.cpp
+++ b/src/messagehandler.cpp
@@ -83,6 +83,13 @@ auto MessageHandler::handle_private_chat(Message &&message) -> void {
         return;
     }
 
+    constexpr auto max_members = 10UZ;
+    if (data.participants().size() > 10UZ) {
+        std::cout << "[SYSTEM] Private chats only support up to " << max_members
+                  << " members." << std::endl;
+        return;
+    }
+
     switch (this->verify_message(message, data.participants().front())) {
     case VerificationStatus::Verified:
         break;


### PR DESCRIPTION
Fix bug - ensure clients aren't DDOS'd by sending messages with 50 million people